### PR TITLE
add SVG Preview Brackets extension

### DIFF
--- a/topics/Optimization.md
+++ b/topics/Optimization.md
@@ -23,6 +23,7 @@
 * [Brackets-svg-code-hints](https://github.com/sprintr/brackets-svg-code-hints)
 * [deSVG](http://benhowdle.im/deSVG/)
 * [SVG Now](https://github.com/davidderaedt/SVG-NOW)
+* [SVG Preview](https://github.com/peterflynn/svg-preview)
 
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)


### PR DESCRIPTION
add SVG Preview Brackets extension in *Optimizing, Fallbacks and Tools* section.