### PR TITLE
Added smil2css

### DIFF
--- a/topics/Optimization-tools.md
+++ b/topics/Optimization-tools.md
@@ -15,6 +15,7 @@
 * [Using SVG to shrink your pngs](http://peterhrynkow.com/how-to-compress-a-png-like-a-jpeg)
 * [SVG MAGIC](https://github.com/dirkgroenen/SVGMagic)
 * [FakeSMILE](http://leunen.me/fakesmile/index.html)
+* [smil2css](https://github.com/webframes/smil2css)
 * [Open Source SVG Editor](http://svg-edit.googlecode.com/svn/branches/stable/editor/svg-editor.html)
 * [Orthogonal](https://github.com/davidchambers/orthogonal)
 * [Iconizr](http://iconizr.com/)


### PR DESCRIPTION
It's also listed in "Libraries", but it probably belongs in both lists. With SMIL being removed from browsers, it may become a necessary library for creating SVG animations, but it's also useful as a converter for supporting SMIL in Internet Explorer.