### PR TITLE
Update sites-using-svg.md

### DIFF
--- a/topics/Sites-using-svg.md
+++ b/topics/Sites-using-svg.md
@@ -14,6 +14,7 @@
 * [playgroundinc.com](http://playgroundinc.com/)
 * [Stat Social](http://www.statsocial.com/)
 * [StretchSketch](http://www.stretchsketch.com/)
-
+* [Gitlab](https://about.gitlab.com/)
+* [Electron](https://electron.atom.io/)
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)


### PR DESCRIPTION
Just added gitlab and electron in the end of the list. They both use SVG in their websites (as a path).