### PR TITLE
Remove duplicate link to 'SVG to Download' section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,6 @@
 	- [Accessible SVG](topics/Accessibility.md)
 	- [Animation](topics/Animation.md)
 	- [Books](topics/Books.md)
-	- [Downloads](topics/Downloads.md)
 	- [Experiments](topics/Experiments.md)
 	- [Filters](topics/Filters.md)
 	- [Follow on Twitter](topics/Follow-twitter.md)


### PR DESCRIPTION
Both 'Downloads' and 'SVG to Download' link in the readme were pointing to the Downloads.md file, I kept the 'SVG to Download' version as that's the title inside Downloads.md