### PR TITLE
docs: Fix simple typo, wtih -> with

### DIFF
--- a/topics/Animation.md
+++ b/topics/Animation.md
@@ -21,7 +21,7 @@
 * [How to create an infographic with SVG](http://designmodo.com/svg-infographic/)
 * [How to Self Drawing SVG Animation](http://codepen.io/MyXoToD/blog/howto-self-drawing-svg-animation)
 * [How to use animateTransform for inline SVG](https://webdesign.tutsplus.com/tutorials/how-to-use-animatetransform-for-inline-svg-animation--cms-22296)
-* [Interactive Infographic wtih SVG and CSS animations](http://tympanus.net/codrops/2013/02/06/interactive-infographic-with-svg-and-css-animations/)
+* [Interactive Infographic with SVG and CSS animations](http://tympanus.net/codrops/2013/02/06/interactive-infographic-with-svg-and-css-animations/)
 * [Intermediate SVG–Animating with snap.svg](http://unicorn-ui.com/blog/intermediate-svg.html)
 * [Jump Loader Animation with GSAP](http://tympanus.net/codrops/2015/03/25/jump-loader-animation-svg-gsap/)
 * [Loading Animation with SVG](https://github.com/jxnblk/loading)


### PR DESCRIPTION
There is a small typo in topics/Animation.md.

Should read `with` rather than `wtih`.

