### PR TITLE
Fix SVG.js link

### DIFF
--- a/topics/Libraries.md
+++ b/topics/Libraries.md
@@ -27,7 +27,7 @@
 * [SnapFoo](http://yuschick.github.io/SnapFoo/)
 * [SeenJS](https://github.com/themadcreator/seen)
 * [svg-pan-zoom](https://github.com/ariutta/svg-pan-zoom)
-* [SVG.js](http://www.svgjs.com/)
+* [SVG.js](https://svgjs.dev/)
 * [svg-captcha](https://github.com/lemonce/svg-captcha)
 * [SVGMaster](https://oaxoa.github.io/SVGMaster/)
 * [SVGnest](https://github.com/Jack000/SVGnest)


### PR DESCRIPTION
Previous link is apparently outdated, leading to a spam site