### PR TITLE
docs: add PolyGlyph to SVG Software

### DIFF
--- a/topics/Softwares.md
+++ b/topics/Softwares.md
@@ -15,6 +15,7 @@
 * [Gravit Designer](https://www.designer.io) - Free (no charge)
 * [CleverBrush](https://www.cleverbrush.com) - Free (no charge) to draw online, there are also white-labeled version available
 * [Text Forge](https://text-forge.github.io/docs) (official plugin) - [FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software)
+* [PolyGlyph](https://polyglyph.io/) - Free credits on signup — AI-powered SVG generation
 
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)


### PR DESCRIPTION
Adds [PolyGlyph](https://polyglyph.io/), an AI-powered SVG generation and editing tool. Type a prompt to generate a vector graphic, then edit it in a lightweight browser-based vector editor. Free credits on signup.


https://github.com/user-attachments/assets/3ee729da-00c9-4222-b194-998ecf81cc09

