### PR TITLE
Add Car Brand Logos to SVG to Download

### DIFF
--- a/topics/Downloads.md
+++ b/topics/Downloads.md
@@ -1,6 +1,7 @@
 ## SVG to Download
 > Some SVG resources to download and enjoy.
 
+* [Car Brand Logos](https://github.com/vehiclespecs/brand-logos) - 184 automotive brand logos to download (100 SVG + 84 PNG), from mass-market to supercar and EV-only marques.
 * [Flat Color Icons](https://github.com/icons8/flat-color-icons)
 * [Freepik](https://www.freepik.com/)
 * [Loading.io](http://loading.io/) - Build Your Ajax Loading Icons with SVG/CSS/GIF.


### PR DESCRIPTION
Adds Car Brand Logos to the SVG to Download section.

An open collection of 184 car brand logos - 100 SVG plus 84 PNG - covering mass-market makes, supercar marques, historical brands, and EV-only manufacturers. MIT-licensed repository structure, jsDelivr CDN-ready, with a brands.json manifest mapping brand name to filename. Sits alongside the section's other downloadable logo and vector resources.