### PR TITLE
Add excalidraw-render

### DIFF
--- a/topics/Optimization-tools.md
+++ b/topics/Optimization-tools.md
@@ -6,6 +6,7 @@
 * [Convertio](https://convertio.co)
 * [Create Paths Online](http://jxnblk.com/paths/)
 * [deSVG](http://benhowdle.im/deSVG/)
+* [excalidraw-render](https://github.com/shivama205/excalidraw-render) - Clean, browser-free `.excalidraw` to SVG/PNG renderer. Pure Python + cairosvg; no Node, no headless browser.
 * [Export SVG for the web with Illustrator](http://creativedroplets.com/export-svg-for-the-web-with-illustrator-cc/)
 * [FakeSMILE](http://leunen.me/fakesmile/index.html)
 * [FastTool SVG Tools](https://fasttool.app/category/image) - Browser-based SVG to PNG conversion, SVG optimization, and related image utilities with client-side processing.


### PR DESCRIPTION
Adds [excalidraw-render](https://github.com/shivama205/excalidraw-render) to the Optimizing, Fallbacks and Tools section.

It's a pure-Python CLI + library that renders .excalidraw files to SVG or PNG. Useful when you want to bake Excalidraw diagrams into docs / static sites / CI without spinning up Node + node-canvas or a headless browser.

- Install: pip install excalidraw-render (or brew install shivama205/tap/excalidraw-render)
- MIT licensed
- Repo: https://github.com/shivama205/excalidraw-render