### PR TITLE
Add motifmint to SVG Software

### DIFF
--- a/topics/Softwares.md
+++ b/topics/Softwares.md
@@ -16,6 +16,7 @@
 * [CleverBrush](https://www.cleverbrush.com) - Free (no charge) to draw online, there are also white-labeled version available
 * [Text Forge](https://text-forge.github.io/docs) (official plugin) - [FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software)
 * [PolyGlyph](https://polyglyph.io/) - Free credits on signup — AI-powered SVG generation
+* [motifmint](https://oss.cver.net/motifmint/) - [FOSS](https://en.wikipedia.org/wiki/Free_and_open-source_software), in-browser raster-to-SVG tracer with a recolor studio and SVG/favicon export
 
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)


### PR DESCRIPTION
Adds motifmint — an in-browser raster-to-SVG tracer (VTracer/WASM) with a recolor studio and SVG/favicon export. MIT, no upload.