### PR TITLE
Add GeoIcons to the Icons list

### DIFF
--- a/topics/Icons.md
+++ b/topics/Icons.md
@@ -8,6 +8,7 @@
 * [Customizable svg icons css variables](http://codepen.io/AmeliaBR/post/customizable-svg-icons-css-variables)
 * [Feather](https://feathericons.com)
 * [Fontastic](http://fontastic.me/faq)
+* [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakeable SVG components.
 * [Glyph Smarticons](http://glyph.smarticons.co/)
 * [Google Fundamentals - Use SVG as icons](https://developers.google.com/web/fundamentals/media/images/use-icons)
 * [Hybrid SVG icons](http://hybicon.softwaretailoring.net/)

--- a/topics/Icons.md
+++ b/topics/Icons.md
@@ -8,7 +8,7 @@
 * [Customizable svg icons css variables](http://codepen.io/AmeliaBR/post/customizable-svg-icons-css-variables)
 * [Feather](https://feathericons.com)
 * [Fontastic](http://fontastic.me/faq)
-* [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakeable SVG components.
+* [GeoIcons](https://geoicons.io) - Geographic map icons as tree-shakable SVG components.
 * [Glyph Smarticons](http://glyph.smarticons.co/)
 * [Google Fundamentals - Use SVG as icons](https://developers.google.com/web/fundamentals/media/images/use-icons)
 * [Hybrid SVG icons](http://hybicon.softwaretailoring.net/)


### PR DESCRIPTION
Adds GeoIcons to the Icons list.

GeoIcons is a set of geographic map-shape icons covering every country, territory, and world region, each a tree-shakable SVG component (React, Vue, Angular, and vanilla JS), themeable with currentColor. 

Placed alphabetically between Fontastic and Glyph Smarticons.

Site: https://geoicons.io
Source: https://github.com/getgeoicons/geoicons