### PR TITLE
Add Pixel Art to SVG

### DIFF
--- a/topics/Optimization-tools.md
+++ b/topics/Optimization-tools.md
@@ -17,6 +17,7 @@
 * [Optimizing SVG for Web](http://web-design-weekly.com/2014/10/22/optimizing-svg-web/)
 * [Orthogonal](https://github.com/davidchambers/orthogonal)
 * [PicSVG](http://picsvg.com/fr/)
+* [Pixel Art to SVG](https://pixel-to-svg.com/) - Pixel-art-aware PNG to SVG converter that keeps the grid: one rectangle per cell, merged with greedy meshing instead of contour tracing. Runs fully in the browser, no upload.
 * [Scour](http://www.codedread.com/scour/)
 * [Script to export PSD to SVG](http://hackingui.com/design/export-photoshop-layer-to-svg/)
 * [smil2css](https://github.com/webframes/smil2css)


### PR DESCRIPTION
Adds [Pixel Art to SVG](https://pixel-to-svg.com/) to Optimizing, Fallbacks and Tools (alphabetical position, after PicSVG).

Why it fits: existing converters in the list are general bitmap tracers; this one is specific to pixel art — it treats the raster as a known grid (one rectangle per cell, merged by greedy meshing) instead of inferring contours, so intentional stair-steps are preserved. Processing is fully client-side, images never leave the browser.

Reproducible before/after examples with a structural verification test: https://github.com/Kfor/pixel-art-to-svg-examples

Checked the contributing guidelines: no duplicate in the list, English link, description added, no trailing whitespace.