### PR TITLE
Add Brush Photo & Video Library

### DIFF
--- a/topics/Libraries.md
+++ b/topics/Libraries.md
@@ -43,7 +43,7 @@
 * [VLEX](https://github.com/indus/VLEX)
 * [Walkway](http://www.connoratherton.com/walkway)
 * [wheelnav.js](http://wheelnavjs.softwaretailoring.net)
+* [Brush Photo & Video Library](https://github.com/IgorShadurin/brush-photo-video-lib) - Renders repeated Unicode text along smooth SVG paths over embedded photos, with dependency-free ports for 20 languages.
 
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)
-

--- a/topics/Libraries.md
+++ b/topics/Libraries.md
@@ -4,6 +4,7 @@
 * [Animate Plus](https://github.com/bendc/animateplus)
 * [Bonsai.js](http://bonsaijs.org/)
 * [Brainmap.js](https://github.com/chihebnabil/brainmap.js)
+* [Brush Photo & Video Library](https://github.com/IgorShadurin/brush-photo-video-lib) - Renders repeated Unicode text along smooth SVG paths over embedded photos, with dependency-free ports for 20 languages.
 * [C3.js](https://github.com/masayuki0812/c3)
 * [Charted](http://www.charted.co/)
 * [Chartist.js](http://gionkunz.github.io/chartist-js/)
@@ -43,7 +44,6 @@
 * [VLEX](https://github.com/indus/VLEX)
 * [Walkway](http://www.connoratherton.com/walkway)
 * [wheelnav.js](http://wheelnavjs.softwaretailoring.net)
-* [Brush Photo & Video Library](https://github.com/IgorShadurin/brush-photo-video-lib) - Renders repeated Unicode text along smooth SVG paths over embedded photos, with dependency-free ports for 20 languages.
 
 ---
 [Back to Home](https://github.com/willianjusten/awesome-svg)


### PR DESCRIPTION
## Summary

Adds Brush Photo & Video Library to the SVG libraries section. It converts drawn pointer points into rounded SVG paths, lays repeated Unicode text along them with distance-based spacing, and embeds the source photo in a standalone SVG. The repository provides the same dependency-free algorithm in 20 languages.

Live demo: https://text-brush.com?utm_source=gh_brush_lib